### PR TITLE
Support matrix jobs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,8 +23,14 @@ Put a ``jenkins.yml`` file at the root of the project. This file contains a
 mapping of ``JOB_NAME`` to scripts. For example::
 
 
-  app-tests: |
-    tox -r
+  app-lint: |
+    flake8 app/
+
+  app-tests:
+    axis:
+      TOXENV: [py27, py34, py35]
+    script: |
+      tox -r
 
   app-doc:
     script: |

--- a/jenkins_yml.py
+++ b/jenkins_yml.py
@@ -51,6 +51,16 @@ def console_script():
         logger.warn("Job not defined for this commit. Skipping.")
         sys.exit(0)
 
+    if isinstance(config, dict) and 'axis' in config:
+        for name, values in config['axis'].items():
+            if name not in os.environ:
+                logger.error("Missing axis %s value.", name)
+                sys.exit(1)
+            current = os.environ[name]
+            if current not in values:
+                logger.warn("%s=%s not available. Skipping.", name, current)
+                sys.exit(0)
+
     call_runner(os.environ.get('JENKINS_YML_RUNNER', 'unconfined'), config)
 
 

--- a/sandbox/jenkins.yml
+++ b/sandbox/jenkins.yml
@@ -16,3 +16,10 @@ overwrite-runner:
   runner: unconfined
   script: |
     : $JOB_NAME
+
+matrix:
+  axis:
+    AXE1: [a, b]
+  script: |
+    : $JOB_NAME
+    : $AXE1

--- a/tests.sh
+++ b/tests.sh
@@ -21,5 +21,9 @@ JOB_NAME=simple jenkins-yml-runner |& grep -C 10 simple
 JOB_NAME=script jenkins-yml-runner
 JOB_NAME=overwrite-runner jenkins-yml-runner
 ! JOB_NAME=overwrite-runner-inexistant jenkins-yml-runner
+AXE1=a JOB_NAME=matrix jenkins-yml-runner
+AXE1=b JOB_NAME=matrix jenkins-yml-runner
+AXE1=inexistant JOB_NAME=matrix jenkins-yml-runner
+! MISSING_AXE1= JOB_NAME=matrix jenkins-yml-runner
 
 : SUCCESS


### PR DESCRIPTION
- Axis are defined in `$JOB_NAME:axis`.
- Each axis must be defined in env. Else job fails.
- If a value for an axis is not in current yml, job is skipped.

This way, we can setup in jenkins the union of all yml axis values, each build will skip the value not relevant.