### PR TITLE
Don't set push trigger

### DIFF
--- a/jenkins_yml/job.py
+++ b/jenkins_yml/job.py
@@ -49,7 +49,7 @@ class Job(object):
             xml = ET.fromstring(xml)
 
         el = xml.find('./assignedNode')
-        config['node_filter'] = el.text or '' if el else ''
+        config['node_filter'] = el.text if el is not None else ''
 
         for axis in xml.findall('./axes/hudson.matrix.TextAxis'):
             axis_name = axis.find('name').text

--- a/jenkins_yml/templates/job.j2
+++ b/jenkins_yml/templates/job.j2
@@ -11,10 +11,6 @@
   <hudson.triggers.TimerTrigger>
     <spec>{{ periodic }}</spec>
   </hudson.triggers.TimerTrigger>
-{% else %}
-  <com.cloudbees.jenkins.GitHubPushTrigger plugin="github@1.19.1">
-    <spec></spec>
-  </com.cloudbees.jenkins.GitHubPushTrigger>
 {% endif %}
 </triggers>
 <concurrentBuild>true</concurrentBuild>

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -101,4 +101,4 @@ class TestXml(TestCase):
         ).as_xml()
 
         job = Job.from_xml('freestyle', xml)
-        assert '!windows' == job.config['node_filter']
+        assert '!windows' == job.config['node_filter'], job.config

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -32,13 +32,11 @@ class TestFreestyle(TestCase):
         assert '!windows' in xml
         assert 'PARAM1' in xml
         assert 'default1' in xml
-        assert 'GitHubPushTrigger' in xml
         assert 'TimerTrigger' not in xml
 
         config['periodic'] = 'H 0 * * *'
         xml = Job(name='freestyle', config=config).as_xml()
 
-        assert 'GitHubPushTrigger' not in xml
         assert 'TimerTrigger' in xml
         assert 'H 0 * * *' in xml
 
@@ -59,12 +57,10 @@ class TestMatrix(TestCase):
         assert 'val1' in xml
         assert 'val2' in xml
         assert 'master' in xml
-        assert 'GitHubPushTrigger' in xml
         assert 'TimerTrigger' not in xml
 
         config['periodic'] = 'H 0 * * *'
         xml = Job(name='freestyle', config=config).as_xml()
 
-        assert 'GitHubPushTrigger' not in xml
         assert 'TimerTrigger' in xml
         assert 'H 0 * * *' in xml


### PR DESCRIPTION
Avoid jenkins warning on missing webhook. This requires a scheduler that
does not require this option.